### PR TITLE
mpeg2: use io.Reader for ts demuxer

### DIFF
--- a/mp4/mp4muxer_test.go
+++ b/mp4/mp4muxer_test.go
@@ -176,7 +176,14 @@ func TestMuxAAC(t *testing.T) {
 }
 
 func TestMuxMp4(t *testing.T) {
-	tsfile := `demo.ts`         // input
+	tsfilename := `demo.ts`     // input
+	tsfile, err := os.Open(tsfilename)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer tsfile.Close()
+
 	mp4filename := "test14.mp4" // output
 	mp4file, err := os.OpenFile(mp4filename, os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
@@ -189,11 +196,6 @@ func TestMuxMp4(t *testing.T) {
 	vtid := muxer.AddVideoTrack(MP4_CODEC_H264)
 	atid := muxer.AddAudioTrack(MP4_CODEC_AAC, 0, 16, 44100)
 
-	buf, err := ioutil.ReadFile(tsfile)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("read %d size\n", len(buf))
 	afile, err := os.OpenFile("r.aac", os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
 		fmt.Println(err)
@@ -219,11 +221,10 @@ func TestMuxMp4(t *testing.T) {
 		}
 	}
 
-	err = demuxer.Input(buf)
+	err = demuxer.Input(tsfile)
 	if err != nil {
 		panic(err)
 	}
-	demuxer.Flush()
 
 	err = muxer.Writetrailer()
 	if err != nil {

--- a/mpeg2/ts-demuxer.go
+++ b/mpeg2/ts-demuxer.go
@@ -127,18 +127,20 @@ func (demuxer *TSDemuxer) Input(r io.Reader) error {
         _, err := io.ReadFull(r, buf)
         if err != nil {
             if errors.Is(err, io.EOF) {
-                return nil
+                break
             } else {
                 return errNeedMore
             }
         }
     }
+    demuxer.flush()
+    return nil
 }
 
-func (demuxer *TSDemuxer) Flush() {
+func (demuxer *TSDemuxer) flush() {
     for _, pm := range demuxer.programs {
         for _, stream := range pm.streams {
-            if len(stream.pkg.payload) == 0 {
+            if stream.pkg == nil || len(stream.pkg.payload) == 0 {
                 continue
             }
             if demuxer.OnFrame != nil {

--- a/mpeg2/ts-proto.go
+++ b/mpeg2/ts-proto.go
@@ -118,7 +118,10 @@ func (pkg *TSPacket) DecodeHeader(bs *codec.BitStream) error {
         if pkg.Field == nil {
             pkg.Field = new(Adaptation_field)
         }
-        pkg.Field.Decode(bs)
+        err := pkg.Field.Decode(bs)
+        if err != nil {
+            return err
+        }
     }
     return nil
 }


### PR DESCRIPTION
Hi again :D
this PR is similar to #8 but for the ts demuxer.
With this, instead of a byte slice the ts demuxer reads from an `io.Reader`. This makes it possible to demux larger .ts files since they do not have to be loaded completely into memory.

It also makes the `Flush` function private and automatically calls it at the end of `Input` so users do not have to think about it.
Additionally, there was a nil dereference bug in Flush that was triggered when the ts file contained a pes private stream without any packets.

The last commit https://github.com/yapingcat/gomedia/commit/6dbd0a46d3c3c5f3e0477c655f648d4c3040852a tries to fix some decode errors that were silently ignored.
For pes_pkg.Decode I had to add a special case in ts-demuxer, because you added an error when the remaining ts packet data is smaller than the expected pes packet data with commit [5fbdc43](https://github.com/yapingcat/gomedia/commit/5fbdc43014aca07cdf7b8e82acb39fddf95e9411#diff-99927264ea7cbac2e47e66509cdfaadc4bacb7a808b9d9c11638a866832a76a6R211). For the ts demuxer the short read is the normal behavior, but I did not want to remove the error in case the Decode function is used somewhere else. Maybe the error is needed for the ps demuxer? (I did not test that).