### PR TITLE
mp4: muxer auto detect chanelCount & sampleRate for aac

### DIFF
--- a/example/example_covert_flv_to_mp4.go
+++ b/example/example_covert_flv_to_mp4.go
@@ -24,7 +24,7 @@ func main() {
 		return
 	}
 	vtid := muxer.AddVideoTrack(mp4.MP4_CODEC_H264)
-	atid := muxer.AddAudioTrack(mp4.MP4_CODEC_AAC, 0, 16, 44100)
+	atid := muxer.AddAudioTrack(mp4.MP4_CODEC_AAC)
 
 	flvfilereader, _ := os.Open(os.Args[1])
 	defer flvfilereader.Close()

--- a/flv/flv-muxer.go
+++ b/flv/flv-muxer.go
@@ -203,7 +203,7 @@ func (muxer *AACMuxer) Write(frames []byte, pts uint32, dts uint32) [][]byte {
         hdr.Decode(aac)
         if muxer.updateSequence {
             asc, _ := codec.ConvertADTSToASC(aac)
-            tags = append(tags, WriteAudioTag(asc, FLV_AAC, true))
+            tags = append(tags, WriteAudioTag(asc.Encode(), FLV_AAC, true))
             muxer.updateSequence = false
         }
         tags = append(tags, WriteAudioTag(aac[7:], FLV_AAC, false))

--- a/mp4/mp4demuxer.go
+++ b/mp4/mp4demuxer.go
@@ -260,9 +260,11 @@ func (demuxer *MovDemuxer) ReadPacket() (*AVPacket, error) {
             if !ok {
                 panic("must init aacExtraData first")
             }
-            aacframe := codec.ConvertASCToADTS(aacExtra.asc, len(sample)+7)
-            aacframe = append(aacframe, sample...)
-            avpkg.Data = aacframe
+            adts, err := codec.ConvertASCToADTS(aacExtra.asc, len(sample)+7)
+            if err != nil {
+                return nil, err
+            }
+            avpkg.Data = append(adts.Encode(), sample...)
         } else {
             avpkg.Data = sample
         }

--- a/mp4/mp4muxer.go
+++ b/mp4/mp4muxer.go
@@ -239,8 +239,6 @@ type Movmuxer struct {
     mdatOffset  uint32
     tracks      map[uint32]*mp4track
     duration    uint32
-    width       uint32
-    height      uint32
 }
 
 func CreateMp4Muxer(w io.WriteSeeker) (*Movmuxer, error) {
@@ -463,10 +461,14 @@ func (muxer *Movmuxer) writeH264(track *mp4track, h264 []byte, pts, dts uint64) 
             tmp := make([]byte, len(nalu))
             copy(tmp, nalu)
             h264extra.spss = append(h264extra.spss, tmp)
-            if muxer.width == 0 || muxer.height == 0 {
-                muxer.width, muxer.height = codec.GetH264Resolution(h264extra.spss[0])
-                track.width = muxer.width
-                track.height = muxer.height
+            if track.width == 0 || track.height == 0 {
+                width, height := codec.GetH264Resolution(h264extra.spss[0])
+                if track.width == 0 {
+                    track.width = width
+                }
+                if track.height == 0 {
+                    track.height = height
+                }
             }
         case codec.H264_NAL_PPS:
             ppsid := codec.GetPPSIdWithStartCode(nalu)
@@ -528,10 +530,14 @@ func (muxer *Movmuxer) writeH265(track *mp4track, h265 []byte, pts, dts uint64) 
         switch nalu_type {
         case codec.H265_NAL_SPS:
             h265extra.hvccExtra.UpdateSPS(nalu)
-            if muxer.width == 0 || muxer.height == 0 {
-                muxer.width, muxer.height = codec.GetH265Resolution(nalu)
-                track.width = muxer.width
-                track.height = muxer.height
+            if track.width == 0 || track.height == 0 {
+                width, height := codec.GetH265Resolution(nalu)
+                if track.width == 0 {
+                    track.width = width
+                }
+                if track.height == 0 {
+                    track.height = height
+                }
             }
         case codec.H265_NAL_PPS:
             h265extra.hvccExtra.UpdatePPS(nalu)


### PR DESCRIPTION
Hi,
this is another change I made in my fork.  
It autodetects the channel count and sample rate for aac audio tracks when muxing mp4's, similar to how the video resolution is autodetected.  

It adds a generic `AddTrack` function without any options to the muxer. But I am not that happy with the name, it will likely break in the future if more arguments are needed.  
Another option would be to use a function for each codec, something like this:
```go
func (muxer *Movmuxer) AddH264Track() uint32
func (muxer *Movmuxer) AddH265Track() uint32
func (muxer *Movmuxer) AddAACTrack() uint32
// not sure if the G711 codecs could also support no arguments functions with auto detection
func (muxer *Movmuxer) AddG711ATrack(channelcount uint8, sampleBits uint8, sampleRate uint) uint32
func (muxer *Movmuxer) AddG711UTrack(channelcount uint8, sampleBits uint8, sampleRate uint) uint32
```
and use the more generic names for functions with all track options:
```go
func (muxer *Movmuxer) AddVideoTrack(cid MP4_CODEC_TYPE, width uint32, height uint32) uint32
func (muxer *Movmuxer) AddAudioTrack(cid MP4_CODEC_TYPE, channelcount uint8, sampleBits uint8, sampleRate uint) uint32
```
Whereby I am not sure whether manually setting the width & height will ever be useful or needed 😄 
But it more clearly differentiates the auto config functions from the expert/technical functions.
Let me know what you prefer I can change the PR accordingly.